### PR TITLE
Fix wrong types when imported from NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,17 +8,22 @@
   ],
   "main": "dist/dedent.umd.js",
   "module": "dist/dedent.mjs",
-  "typings": "dist/types/dedent.d.ts",
+  "types": "./dist/dedent.d.ts",
   "exports": {
-    ".": [
-      {
-        "types": "dist/types/dedent.d.ts",
-        "browser": "./dist/dedent.umd.js",
-        "require": "./dist/dedent.umd.js",
-        "import": "./dist/dedent.mjs"
+    ".": {
+      "import": {
+        "types": "./dist/dedent.d.mts",
+        "default": "./dist/dedent.mjs"
       },
-      "./dist/dedent.umd.js"
-    ],
+      "require": {
+        "types": "./dist/dedent.d.ts",
+        "default": "./dist/dedent.umd.js"
+      },
+      "browser": {
+        "types": "./dist/dedent.d.ts",
+        "default": "./dist/dedent.umd.js"
+      }
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -37,6 +42,7 @@
     "build": "run-s -n build:*",
     "build:rollup": "rollup -c rollup.config.ts",
     "build:ts": "tsc --project tsconfig.build.json",
+    "build:fix-npm-types": "mv dist/dedent.d.ts dist/dedent.d.mts && sed 's/export default/export =/' dist/dedent.d.mts > dist/dedent.d.ts",
     "lint": "run-s -n lint:*",
     "lint:prettier": "npm run test:lint:prettier -- --write",
     "lint:ts": "npm run test:lint:ts -- --fix",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build": "run-s -n build:*",
     "build:rollup": "rollup -c rollup.config.ts",
     "build:ts": "tsc --project tsconfig.build.json",
-    "build:fix-npm-types": "mv dist/dedent.d.ts dist/dedent.d.mts && sed 's/export default/export =/' dist/dedent.d.mts > dist/dedent.d.ts",
+    "build:fix-npm-types": "node scripts/fix-npm-types.mjs",
     "lint": "run-s -n lint:*",
     "lint:prettier": "npm run test:lint:prettier -- --write",
     "lint:ts": "npm run test:lint:ts -- --fix",

--- a/scripts/fix-npm-types.mjs
+++ b/scripts/fix-npm-types.mjs
@@ -1,0 +1,9 @@
+import fs from 'node:fs/promises';
+
+const tsPath = './dist/dedent.d.ts';
+const mtsPath = './dist/dedent.d.mts';
+
+const source = await fs.readFile(tsPath, 'utf8');
+
+await fs.writeFile(tsPath, source.replace('export default', 'export ='));
+await fs.writeFile(mtsPath, source);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "inlineSources": true,
     "declaration": true,
     "allowSyntheticDefaultImports": true,
-    "declarationDir": "dist/types",
+    "declarationDir": "./dist",
     "typeRoots": ["node_modules/@types"]
   },
   "exclude": ["dist"],


### PR DESCRIPTION
Fixes https://github.com/jridgewell/string-dedent/issues/50

`npm pack` build artifact passes https://arethetypeswrong.github.io/

There's probably a better way of doing this without resorting to grepping with a custom node script, but `@rollup/plugin-typescript` doesn't seem to have any option that enables the weird `export =` syntax that seems to be necessary for the UMD output.